### PR TITLE
run' returns an internal type JSON

### DIFF
--- a/Database/RethinkDB/Driver.hs
+++ b/Database/RethinkDB/Driver.hs
@@ -64,10 +64,12 @@ run :: (Expr query, Result r) => RethinkDBHandle -> query -> IO r
 run h = runOpts h []
 
 -- | Run a given query and return a JSON
-run' :: Expr query => RethinkDBHandle -> query -> IO [JSON]
+run' :: Expr query => RethinkDBHandle -> query -> IO [Value]
 run' h t = do
   c <- run h t
-  collect c
+  liftM (map unwrapValue) (collect c)
+  where
+    unwrapValue (JSON val) = val
 
 -- | Convert the raw query response into useful values
 class Result r where

--- a/Database/RethinkDB/ReQL.hs
+++ b/Database/RethinkDB/ReQL.hs
@@ -326,7 +326,7 @@ instance Num ReQL where
   a + b = op ADD (a, b) ()
   a * b = op MUL (a, b) ()
   a - b = op SUB (a, b) ()
-  negate a = op SUB (0, a) ()
+  negate a = op SUB (0 :: Double, a) ()
   abs n = op BRANCH (op TermType.LT (n, 0 :: Double) (), negate n, n) ()
   signum n = op BRANCH (op TermType.LT (n, 0 :: Double) (),
                         -1 :: Double,


### PR DESCRIPTION
So I was working with RethinkDB and noticed that `run' :: ... -> IO [JSON]`, which I did not enjoy since `JSON` is an internal type probably used to define instances for. Therefore this pull request changes the type to `run :: ... -> IO [Value]`, which is the real Data.Aeson format.

I bumped into this problem using the Data.Aeson.Bson and Data.Aeson-Bson packages.

I also could not compile the code initially without declaring the type of the integer 0 in line 329 ReQL.hs to Double, so I included that fix here as well.
