### PR TITLE
Fixed compilation error

### DIFF
--- a/Database/RethinkDB/ReQL.hs
+++ b/Database/RethinkDB/ReQL.hs
@@ -269,7 +269,7 @@ toDouble _ = Nothing
 
 varsOf :: [BaseReQL] -> Maybe [Double]
 varsOf = sequence . map varOf
-    
+
 varOf :: BaseReQL -> Maybe Double
 varOf (BaseReQL VAR Nothing [BaseReQL DATUM (Just d) [] []] []) = toDouble d
 varOf _ = Nothing
@@ -326,7 +326,7 @@ instance Num ReQL where
   a + b = op ADD (a, b) ()
   a * b = op MUL (a, b) ()
   a - b = op SUB (a, b) ()
-  negate a = op SUB (0, a) ()
+  negate a = op SUB (0 :: Double, a) ()
   abs n = op BRANCH (op TermType.LT (n, 0 :: Double) (), negate n, n) ()
   signum n = op BRANCH (op TermType.LT (n, 0 :: Double) (),
                         -1 :: Double,


### PR DESCRIPTION
Fixes the following error:

```
[21 of 28] Compiling Database.RethinkDB.ReQL ( Database/RethinkDB/ReQL.hs, dist/dist-sandbox-8cf38cea/build/Database/RethinkDB/ReQL.o )

Database/RethinkDB/ReQL.hs:329:14:
    No instance for (Expr t0) arising from a use of `op'
    The type variable `t0' is ambiguous
    Possible fix: add a type signature that fixes these type variable(s)
    Note: there are several potential instances:
      instance (Expr a, Expr b, Expr c, Expr d, Expr e) =>
               Expr (a, b, c, d, e)
        -- Defined at Database/RethinkDB/ReQL.hs:480:10
      instance (Expr a, Expr b, Expr c, Expr d) => Expr (a, b, c, d)
        -- Defined at Database/RethinkDB/ReQL.hs:477:10
      instance (Expr a, Expr b, Expr c) => Expr (a, b, c)
        -- Defined at Database/RethinkDB/ReQL.hs:474:10
      ...plus 24 others
    In the expression: op SUB (0, a) ()
    In an equation for `negate': negate a = op SUB (0, a) ()
    In the instance declaration for `Num ReQL'

Database/RethinkDB/ReQL.hs:329:22:
    No instance for (Num t0) arising from the literal `0'
    The type variable `t0' is ambiguous
    Possible fix: add a type signature that fixes these type variable(s)
    Note: there are several potential instances:
      instance Num ReQL -- Defined at Database/RethinkDB/ReQL.hs:324:10
      instance Num EnumCode -- Defined in `Text.ProtocolBuffers.Basic'
      instance Num FieldId -- Defined in `Text.ProtocolBuffers.Basic'
      ...plus 16 others
    In the expression: 0
    In the second argument of `op', namely `(0, a)'
    In the expression: op SUB (0, a) ()
```
