### PR TITLE
add ability to get profile from queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist/
 *.hi-boot
 .cabal-sandbox/
 cabal.sandbox.config
+.ghci
+.lvimrc

--- a/Database/RethinkDB.hs
+++ b/Database/RethinkDB.hs
@@ -16,7 +16,7 @@ module Database.RethinkDB (
   RethinkDBHandle,
   close,
   use,
-  run, run', runOpts,
+  run, run', runProfile, runProfile', runOpts,
   ReQL,
   Datum(..),
   ToDatum(..), FromDatum(..), fromDatum,


### PR DESCRIPTION
@AtnNn switching from `MVar` to `TMVar` solves the atomic issue that we would run into on 7.6. `mkWeakTMVar` is not part of the stm lib yet. There is a submitted patch, but is not slated to be accepted until 7.10. I just created a `Utils.TMVar` and borrowed the methods that we use, along with `mkWeakTMVar` and added a `modifyTMVar` akin to `modifyMVar`. All tests are passing on 7.6 and 7.8, and I did not see any performance regressions. Let me know if this works for you or if you have any comments/concerns.