### PR TITLE
Constraints

### DIFF
--- a/rethinkdb.cabal
+++ b/rethinkdb.cabal
@@ -32,7 +32,7 @@ library
         network >=2.4 && <2.7,
         mtl >=2.1 && <2.3,
         vector ==0.10.*,
-        time ==1.4.*,
+        time >= 1.4,
         utf8-string ==0.3.*,
         binary >=0.5 && <0.8,
         scientific ==0.3.*,


### PR DESCRIPTION
Yesterday I couldn't install `timerep == 2.0.0` because it requires `time >= 1.5`. 

Do we know that this package doesn't work with time 1.5? I know the community is split on upper bounds, but I'm sure time will stay pretty backwards compatible. 

Are there other upper constraints we could remove? 