### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -3,7 +3,7 @@
 module Main where
 
 import Control.Exception
-import Database.RethinkDB.NoClash
+import Database.RethinkDB.NoClash hiding (wait)
 import qualified Database.RethinkDB as R
 import Criterion.Main
 import Control.Monad


### PR DESCRIPTION
`wait` from `Database.RethinkDB.NoClash` conflicts with the `wait` from `Control.Concurrent.Async`.

See also https://github.com/iu-parfunc/sc-haskell/issues/7